### PR TITLE
Update ways to access backend API

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+PROXY_TO_URL=https://dracula.betterw8.com
+NEXT_PUBLIC_API_URL=http://localhost:3000/api

--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_URL=https://dracula.betterw8.com

--- a/README.md
+++ b/README.md
@@ -18,6 +18,57 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 This project uses [`next/font`](https://nextjs.org/docs/basic-features/font-optimization) to automatically optimize and load Inter, a custom Google Font.
 
+## Backend API config
+
+- If you set `NEXT_PUBLIC_API_URL`, frontend will use that directly.
+- Otherwise, it will use Next.js proxy at localhost:3000/api/, can set `PROXY_TO_URL` to configure.
+
+Can use env vars and/or `.env*` files, doc:
+https://nextjs.org/docs/pages/building-your-application/configuring/environment-variables#default-environment-variables
+
+### Production backend direct
+
+Default in prod — see `.env.production` file.  
+WON'T WORK until next deploy dracula.betterw8.com supports CORS (next deploy).  
+And may need to visit https://dracula.betterw8.com/schedule in your browser and accept cert?
+
+### Production backend proxied
+
+WON'T WORK until dracula.betterw8.com gets valid cert.
+
+```
+echo PROXY_TO_URL=https://dracula.betterw8.com > .env.local
+npm run dev
+```
+
+### Local backend direct
+
+```
+git clone git@github.com:il-blood-donation-info/blood-donation-backend.git
+cd blood-donation-backend/
+git pull
+docker-compose --env-file db.env up --build
+```
+Leave it running (^C when done).  
+- Every time you start it, visit https://localhost:8443/schedule in your browser and accept (new) self-signed cert or API requests will fail.
+
+Here in UI dir:
+```
+echo NEXT_PUBLIC_API_URL=https://localhost:8443 > .env.local
+npm run dev
+```
+
+### Local backend proxied
+
+Run backend in same way as above.  
+- Here in UI dir, every time you start backend, execute:
+```
+docker run blood-donation-backend_blood-info /bin/cat cert.pem > cert.pem
+export NODE_EXTRA_CA_CERTS=$PWD/cert.pem
+echo PROXY_TO_URL=https://localhost:8443 > .env.local
+npm run dev
+```
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/next.config.js
+++ b/next.config.js
@@ -1,12 +1,25 @@
-const API_URL = process.env.API_URL
+// Try proxying requests to work around CORS (implemented, not deployed yet)
+// and/or self-signed cert.
+
+const dev = process.env.NODE_ENV !== 'production'
+if(dev) {
+  // TODO useless with rewrites: https://github.com/vercel/next.js/issues/21537
+  //process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'
+}
+
+// These have defaults in .env* files.
+console.log(`\
+  Proxying              http://localhost:3000/api -> ${process.env.PROXY_TO_URL}
+  Frontend will access: ${process.env.NEXT_PUBLIC_API_URL}
+`)
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
 	async rewrites() {
 		return [
 			{
-				source: '/:path*',
-				destination: `${API_URL}/:path*`,
+				source: '/api/:path*',
+				destination: `${process.env.PROXY_TO_URL}/:path*`,
 			},
 		]
 	},

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -10,11 +10,6 @@ import GlobalState from './global-state'
 // (Both are under Open Font License)
 const heebo = Heebo({ subsets: ['latin'] })
 
-const dev = process.env.NODE_ENV !== 'production';
-if(dev){
-  process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0"
-}
-
 export default function RootLayout({
   children,
 }: {

--- a/src/app/where/page.tsx
+++ b/src/app/where/page.tsx
@@ -10,7 +10,6 @@ import { AutoComplete } from '../common/components/inputs/auto-complete'
 import { uniq } from 'lodash'
 import { useEffect, useState } from 'react'
 
-
 type scheduleDTO = {
   address: string,
   close_time: string,
@@ -43,7 +42,7 @@ export default function Where() {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const response = await fetch(`${process.env.API_URL}/schedule`)
+        const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/schedule`)
         const fetchLocation = await response.json()
         const locations = adaptToLocations(fetchLocation)
         setLocations(locations)


### PR DESCRIPTION
Followup to @gabbyhagag's work in commit 29fd5e81cb3e65b57b8148dcc1c4b24426ada1d1

- Rename var NEXT_PUBLIC_API_URL so that frontend code [gets it](https://nextjs.org/docs/pages/building-your-application/configuring/environment-variables#bundling-environment-variables-for-the-browser).  
  (it wasn't getting process.env.API_URL so was querying `undefined/schedule`)
- Separate var PROXY_TO_URL for proxy code.
- Discovered NODE_TLS_REJECT_UNAUTHORIZED=0 is useless in `rewrites` :disappointed: 
  So proxy can bypass CORS but requires valid cert.
- Documented how to run with & without proxy, for prod backend & running local backend.
- .env and .env.production defaults.
  - .env.production chosen expecting next backend deploy will fix CORS.
  - [backend cert](https://github.com/il-blood-donation-info/blood-donation-backend/issues/32) will take more time, but that's easier to accept in browser.
- Added logging of actual config used, cause env files & vars can get confusing...

Still a mess, but at least a documented mess ;-)